### PR TITLE
dont exchange libclib_jiio.so

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -13,7 +13,7 @@ mod 'tylerwalts/jdk_oracle',
   :ref => '6d250b86e0dc54ce4331aa8bcbcd3706ca9363cf'
 mod 'teleivo-dcm4chee',
   :git => 'https://github.com/teleivo/puppet-dcm4chee.git',
-  :ref => '127f5ecda436efd93ee47a7b1fdcd3382ca50568'
+  :ref => 'ab865888b378e2b6f3614bfa657bcd15d4c4e14b'
 mod 'teleivo-openmrs',
   :git => 'https://github.com/teleivo/puppet-openmrs.git',
   :ref => '60e8ee04865943aec5ad10d8357a7698de6339f4'


### PR DESCRIPTION
- upgrade puppet-dcm4chee where
  libclib_jiio.so is optional
